### PR TITLE
Refactor lima-and-qemu.pl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,8 +68,8 @@ jobs:
         path: qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
         if-no-files-found: error
     - run: mkdir -p build
-    - run: brew install filemonitor ninja
-    - run: brew install --ignore-dependencies lima # Don't pull in qemu
+    - run: brew install filemonitor ninja go
+    - run: brew install lima
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         HOMEBREW_NO_AUTO_UPDATE: 1
@@ -164,6 +164,7 @@ jobs:
       working-directory: build
     - run: ./appdir-qemu.sh "${{ github.workspace }}/install/usr"
       env:
+        LD_LIBRARY_PATH: ${{ github.workspace }}/install/usr/lib/x86_64-linux-gnu
         VERSION: ${{ steps.version.outputs.VERSION }}
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,29 +22,69 @@ jobs:
       matrix:
         include:
         - { arch: aarch64, runs-on: macos-14 }
-        - { arch: x86_64, runs-on: macos-13 }
+        - { arch: x86_64, runs-on: macos-12 }
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 40
+    timeout-minutes: 120
     steps:
-    - run: mkdir -p build
-    - run: brew install filemonitor ninja
-    - run: brew install --ignore-dependencies lima # Don't pull in qemu
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - run: brew install --build-from-source ./qemu.rb
+        fetch-depth: 0
+    - id: version
+      name: Calculate version
+      shell: bash
+      run: |
+        version=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+        echo "VERSION=${version#v}" >>"$GITHUB_OUTPUT"
+    - name: Uninstall all brew packages and clear cache
+      run: |
+        set -o xtrace
+        brew list | xargs brew uninstall --force
+        brew autoremove
+        brew cleanup
+        rm -rf "$(brew --cache)"
+    - name: Build qemu and all prerequisites from source
+      run: |
+        set -o xtrace
+        brew tap-new rd/tap
+        cp qemu.rb "$(brew --repo rd/tap)/Formula/qemu.rb"
+        brew install --overwrite --build-from-source $(brew deps --include-build python@3.11)  python@3.11
+        brew install --overwrite --build-from-source $(brew deps --include-build python@3.12)  python@3.12
+        brew install --overwrite --build-from-source $(brew deps --include-build python@3.13)  python@3.13
+        brew install --build-from-source $(brew deps --include-build rd/tap/qemu) rd/tap/qemu
+        CACHE=$(brew --cache)
+        cp .github/workflows/build.yaml qemu.rb "$CACHE"
+        (cd "$CACHE"; tar -cvzf - *) >qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
       env:
-        HOMEBREW_DEBUG: 1
-        HOMEBREW_VERBOSE: 1
-      timeout-minutes: 20
-    - run: cpan -Ti JSON
-    - run: echo "$PWD/install/bin" >> "$GITHUB_PATH"
-    - run: perl lima-and-qemu.pl alpine
-      timeout-minutes: 10
+        # HOMEBREW_DEBUG: 1
+        # HOMEBREW_VERBOSE: 1
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_UPGRADE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
     - uses: actions/upload-artifact@v4
       with:
-        name: qemu-darwin-${{ matrix.arch }}
-        path: qemu-darwin-${{ matrix.arch }}.tar.gz
+        name: qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}
+        path: qemu-${{ steps.version.outputs.VERSION }}-darwin-source-${{ matrix.arch }}.tar.gz
+        if-no-files-found: error
+    - run: mkdir -p build
+    - run: brew install filemonitor ninja
+    - run: brew install --ignore-dependencies lima # Don't pull in qemu
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_UPGRADE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+    - run: cpan -Ti JSON
+    - run: echo "$PWD/install/bin" >>"$GITHUB_PATH"
+    - run: perl lima-and-qemu.pl alpine
+      timeout-minutes: 10
+      env:
+        VERSION: ${{ steps.version.outputs.VERSION }}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: qemu-${{ steps.version.outputs.VERSION }}-darwin-${{ matrix.arch }}
+        path: qemu-${{ steps.version.outputs.VERSION }}-darwin-${{ matrix.arch }}.tar.gz
         if-no-files-found: error
   linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+        fetch-depth: 0
+    - id: version
+      name: Calculate version
+      shell: bash
+      run: |
+        version=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+        echo "VERSION=${version#v}" >>"$GITHUB_OUTPUT"
     - uses: actions/checkout@v4
       with:
         repository: qemu/qemu
@@ -156,10 +163,12 @@ jobs:
     - run: make install DESTDIR=${{ github.workspace }}/install
       working-directory: build
     - run: ./appdir-qemu.sh "${{ github.workspace }}/install/usr"
+      env:
+        VERSION: ${{ steps.version.outputs.VERSION }}
     - uses: actions/upload-artifact@v4
       with:
-        name: qemu-linux-x86_64
-        path: qemu-linux-x86_64.tar.gz
+        name: qemu-${{ steps.version.outputs.VERSION }}-linux-x86_64
+        path: qemu-${{ steps.version.outputs.VERSION }}-linux-x86_64.tar.gz
         if-no-files-found: error
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/appdir-qemu.sh
+++ b/appdir-qemu.sh
@@ -46,7 +46,9 @@ set -ex
 [ -d "${1}" ] || error "Directory ${1} doesn't exist"
 
 appDir=$1
-dist="qemu-linux-x86_64"
+dist="qemu"
+[[ -n $VERSION ]] && dist="${dist}-${VERSION}"
+dist="${dist}-linux-x86_64"
 
 # Inspired on linuxdeployqt https://github.com/probonopd/linuxdeployqt/blob/master/tools/linuxdeployqt/excludelist.h
 # Linuxdeployqt is a tool created by probonopd, the AppImage creator

--- a/lima-and-qemu.pl
+++ b/lima-and-qemu.pl
@@ -127,8 +127,18 @@ if ($arch eq "aarch64") {
 print "$_ $deps{$_}\n" for sort keys %deps;
 print "\n";
 
-my $dist = "qemu-darwin-$arch";
+# "qemu-9.1.0-macos12-x86_64"
+my $dist = "qemu";
+$dist .= "-$ENV{VERSION}" if $ENV{VERSION};
+$dist .= "-darwin-$arch";
 system("rm -rf /tmp/$dist");
+
+# Record build information
+my $buildenv = "/tmp/$dist/build-env.txt";
+system("mkdir -p /tmp/$dist");
+system("uname -a >>$buildenv");
+system("sw_vers >>$buildenv");
+system("pkgutil --pkg-info=com.apple.pkg.CLTools_Executables >>$buildenv");
 
 # Copy all files to /tmp tree and make all dylib references relative to the
 # /usr/local/bin directory using @executable_path/..
@@ -191,7 +201,7 @@ for my $attr (("com.apple.FinderInfo", "com.apple.ResourceFork")) {
 
 my $repo_root = $FindBin::Bin;
 unlink("$repo_root/$dist.tar.gz");
-system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist $files");
+system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist build-env.txt $files");
 
 exit;
 


### PR DESCRIPTION
The aarch64 version no longer collected the qemu libraries. That's why it was re-implemented by parsing the `otool -L` output. It eventually turned out that the Homebrew had switched to Lima 1.0.0, which uses `--vm-type vz` by default (when available).

The FileMonitor version does not collect kvmvapic.bin and vgabios-virtio.bin. They may not be needed when the VM is run without a display, but it for now it seems safer to keep them in the tarball.

The script has also been changed to re-analyze an existing filemonitor.log. This makes no difference on CI but helps debugging the script.